### PR TITLE
Remove bottle :unneeded

### DIFF
--- a/pdr.rb
+++ b/pdr.rb
@@ -6,7 +6,6 @@ class Pdr < Formula
   desc "docker-compose cli wrapper"
   homepage "https://github.com/pyama86/pdr"
   version "0.0.4"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/pyama86/pdr/releases/download/v0.0.4/pdr_0.0.4_darwin_amd64.tar.gz"


### PR DESCRIPTION
It is deprecated.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the pyama86/ptools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/pyama86/homebrew-ptools/pdr.rb:9
```